### PR TITLE
Add custom snyk init script to handle buildScript dependencies

### DIFF
--- a/src/main/resources/snyk/snyk_init.gradle
+++ b/src/main/resources/snyk/snyk_init.gradle
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2022 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import groovy.json.JsonOutput
+import org.gradle.util.GradleVersion
+
+import java.util.regex.Pattern
+
+// Snyk dependency resolution script for Gradle.
+// Tested on Gradle versions from v2.14 to v6.8.1
+
+// This script does the following: for all the projects in the build file,
+// generate a merged configuration of all the available configurations,
+// and then list the dependencies as a tree.
+
+// It's the responsibility of the caller to pick the project(s) they are
+// interested in from the results.
+
+// CLI usages:
+// gradle -q -I init.gradle snykResolvedDepsJson
+// gradle -q -I init.gradle snykResolvedDepsJson -Pconfiguration=specificConf -PonlySubProject=sub-project
+// gradle -q -I init.gradle snykResolvedDepsJson -Pconfiguration=confNameRegex -PconfAttr=buildtype:debug,usage:java-runtime
+
+// (-q to have clean output, -P supplies args as per https://stackoverflow.com/a/48370451)
+
+// confAttr parameter (supported only in Gradle 3+) is used to perform attribute-based dependency variant matching
+// (important for Android: https://developer.android.com/studio/build/dependencies#variant_aware)
+// Its value is a comma-separated list of key:value pairs. The "key" is a case-insensitive substring
+// of the class name of the attribute (e.g. "buildtype" would match com.android.build.api.attributes.BuildTypeAttr),
+// the value should be a case-insensitive stringified value of the attribute
+
+// Output format:
+//
+// Since Gradle is chatty and often prints a "Welcome" banner even with -q option,
+// the only output lines that matter are:
+// - prefixed "SNYKECHO ": should be immediately printed as debug information by the caller
+// - prefixed "JSONDEPS ": JSON representation of the dependencies trees for all projects in the following format
+
+// interface JsonDepsScriptResult {
+//   defaultProject: string;
+//   projects: ProjectsDict;
+//   allSubProjectNames: string[];
+// }
+// interface ProjectsDict {
+//   [project: string]: GradleProjectInfo;
+// }
+
+// interface GradleProjectInfo {
+//   depGraph: DepGraph;
+//   snykGraph: { [name: string]: SnykGraph };
+//   targetFile: string;
+// }
+// export interface SnykGraph {
+//   name: string;
+//   version: string;
+//   parentIds: string[];
+// }
+
+class SnykGraph {
+
+    def nodes
+    def rootId
+
+    SnykGraph(rootId) {
+        this.nodes = [:]
+        this.rootId = rootId
+    }
+
+    def setNode(key, value) {
+        if (!key) {
+            return
+        }
+        if (this.nodes.get(key)) {
+            return this.nodes.get(key)
+        }
+        if (!value) {
+            return
+        }
+        def vertex = ['name': value.name, 'version': value.version, 'parentIds': [] as Set]
+        this.nodes.put(key, vertex)
+        return vertex
+    }
+
+    def setEdge(parentId, childId) {
+        if (!parentId || !childId || parentId == childId) {
+            return
+        }
+        // root-node will be the graphlib root that first-level deps will be attached to
+        if (parentId != this.rootId) {
+            def parentNode = this.setNode(parentId, null)
+            if (!parentNode) {
+                return
+            }
+        }
+        def childNode = this.setNode(childId, null)
+        if (!childNode || childNode.parentIds.contains(parentId)) {
+            return
+        }
+        childNode.parentIds.add(parentId)
+    }
+
+}
+
+def loadGraph(Iterable deps, SnykGraph graph, parentId, currentChain) {
+    deps.each { dep ->
+        dep.each { d ->
+            def childId = "${d.moduleGroup}:${d.moduleName}@${d.moduleVersion}"
+            if (!graph.nodes.get(childId)) {
+                def childDependency = ['name': "${d.moduleGroup}:${d.moduleName}", 'version': d.moduleVersion]
+                graph.setNode(childId, childDependency)
+            }
+            //  In Gradle 2, there can be several instances of the same dependency present at each level,
+            //  each for a different configuration. In this case, we need to merge the dependencies.
+            if (!currentChain.contains(childId) && d.children) {
+                currentChain.add(childId)
+                loadGraph(d.children, graph, childId, currentChain)
+            }
+            graph.setEdge(parentId, childId)
+        }
+    }
+}
+
+def getSnykGraph(Iterable deps) {
+    def rootId = 'root-node'
+    def graph = new SnykGraph(rootId)
+    def currentChain = new HashSet()
+    loadGraph(deps, graph, rootId, currentChain)
+
+    return graph.nodes
+}
+
+def snykEcho(msg) {
+    println("SNYKECHO $msg")
+}
+
+def matchesAttributeFilter(conf, confAttrSpec) {
+    if (!conf.hasProperty('attributes')) {
+        // Gradle before version 3 does not support attributes
+        return true
+    }
+    def matches = true
+    def attrs = conf.attributes
+    attrs.keySet().each({ attr ->
+        def attrValueAsString = attrs.getAttribute(attr).toString().toLowerCase()
+        confAttrSpec.each({ keyValueFilter ->
+            // attr.name is a class name, e.g. com.android.build.api.attributes.BuildTypeAttr
+            if (attr.name.toLowerCase().contains(keyValueFilter[0]) && attrValueAsString != keyValueFilter[1]) {
+                matches = false
+            }
+        })
+    })
+    return matches
+}
+
+def findMatchingConfigs(confs, confNameFilter, confAttrSpec) {
+    def matching = confs.findAll({ it.name =~ confNameFilter })
+    if (confAttrSpec == null) {
+        // We don't have an attribute spec to match
+        return matching
+    }
+    return matching.findAll({ matchesAttributeFilter(it, confAttrSpec) })
+}
+
+def findProjectConfigs(proj, confNameFilter, confAttrSpec) {
+    def matching = findMatchingConfigs(proj.configurations, confNameFilter, confAttrSpec)
+    //Also pull the `buildScript` classpath configuration here since this contains the build time dependencies (plugins etc)
+    snykEcho("add buildScript classpath configuration")
+    def classpath = proj.getBuildscript().getConfigurations().findAll { it.name == "classpath" }
+    matching.addAll(classpath)
+    if (GradleVersion.current() < GradleVersion.version('3.0')) {
+        proj.configurations.each({ snykEcho("conf.name=$it.name") })
+        return matching
+    }
+    proj.configurations.each({ snykEcho("conf.name=$it.name; conf.canBeResolved=$it.canBeResolved; conf.canBeConsumed=$it.canBeConsumed") })
+    // We are looking for a configuration that `canBeResolved`, because it's a configuration for which 
+    // we can compute a dependency graph and that contains all the necessary information for resolution to happen.
+    // if we cannot find dependencies that can be only resolved but not consumable
+    // we try to find configs that are simultaneously resolvable and consumable
+    // to prevent dependency resolution conflicts (e.g. Cannot choose between the following variants) 
+    // we avoid the coexistence of (canBeResolved: true, canBeConsumed: false) and (canBeResolved: true, canBeConsumed: true) configs
+    def resolvable = matching.findAll({ it.canBeResolved == true })
+    snykEcho("resolvableConfigs=$resolvable")
+    return resolvable
+}
+
+// We are attaching this task to every project, as this is the only reliable way to run it
+// when we start with a subproject build.gradle. As a consequence, we need to make sure we
+// only ever run it once, for the "starting" project.
+def snykDepsConfExecuted = false
+allprojects { currProj ->
+    snykEcho("Current project: $currProj.name")
+    //wait for project to evaluate and the official snyk dependency script to be executed
+    afterEvaluate {
+        //the real script should have added a task with name 'snykResolvedDepsJson'
+        //we simply delete all actions and provide our own.
+        //It would all be nicer if the task would work with properties instead of doing everything in a huge
+        //doLast closure. Otherwise we could just add yet another configuration to a `ListProperty` or similar.
+        currProj.tasks.named('snykResolvedDepsJson').configure {
+            actions = []
+            def onlyProj = project.hasProperty('onlySubProject') ? onlySubProject : null
+            def confNameFilter = (project.hasProperty('configuration')
+                    ? Pattern.compile(configuration, Pattern.CASE_INSENSITIVE)
+                    : /.*/
+            )
+            def confAttrSpec = (project.hasProperty('confAttr')
+                    ? confAttr.toLowerCase().split(',').collect { it.split(':') }
+                    : null
+            )
+
+            doLast { task ->
+                if (snykDepsConfExecuted) {
+                    return
+                }
+                snykEcho('snykResolvedDepsJson task is executing via doLast')
+                // snykEcho("onlyProj=$onlyProj; confNameFilter=$confNameFilter; confAttrSpec=$confAttrSpec")
+                // First pass: scan all configurations that match the attribute filter and collect all attributes
+                // from them, to use unambiguous values of the attributes on the merged configuration.
+                //
+                // Why we need to scan all sub-projects: if a project A depends on B, and only B has some
+                // configurations with attribute C, we still might need attribute C in our configuration
+                // when resolving the project A, so that it selects a concrete variant of dependency B.
+                def allConfigurationAttributes = [:] // Map<Attribute<?>, Set<?>>
+                def attributesAsStrings = [:] // Map<String, Set<string>>
+                rootProject.allprojects.each { proj ->
+                    findMatchingConfigs(proj.configurations, confNameFilter, confAttrSpec)
+                            .each { conf ->
+                                if (!conf.hasProperty('attributes')) {
+                                    // Gradle before version 3 does not support attributes
+                                    return
+                                }
+                                def attrs = conf.attributes
+                                attrs.keySet().each({ attr ->
+                                    def value = attrs.getAttribute(attr)
+                                    if (!allConfigurationAttributes.containsKey(attr)) {
+                                        allConfigurationAttributes[attr] = new HashSet()
+                                        attributesAsStrings[attr.name] = new HashSet()
+                                    }
+                                    allConfigurationAttributes[attr].add(value)
+                                    attributesAsStrings[attr.name].add(value.toString())
+                                })
+                            }
+                }
+
+                def defaultProjectName = task.project.name
+                def allSubProjectNames = []
+                def seenSubprojects = [:]
+                allprojects
+                        .findAll({ it.name != defaultProjectName })
+                        .each({
+                            def projKey = it.name
+                            if (seenSubprojects.get(projKey)) {
+                                projKey = it.path.replace(':', '/').replaceAll(~/(^\/+?)|(\/+$)/, '')
+                                if (projKey == "") {
+                                    projKey = defaultProjectName
+                                }
+                            }
+                            allSubProjectNames.add(projKey)
+                            seenSubprojects[projKey] = true
+                        })
+                def shouldScanProject = {
+                    onlyProj == null ||
+                            (onlyProj == '.' && it.name == defaultProjectName) ||
+                            it.name == onlyProj
+                }
+                def projectsDict = [:]
+
+                snykEcho("defaultProjectName=$defaultProjectName; allSubProjectNames=$allSubProjectNames")
+
+                // These will be used to suggest attribute filtering to the user if the scan fails
+                // due to ambiguous resolution of dependency variants
+                def jsonAttrs = JsonOutput.toJson(attributesAsStrings)
+                println("JSONATTRS $jsonAttrs")
+
+                rootProject.allprojects.findAll(shouldScanProject).each { proj ->
+                    snykEcho("processing project: name=$proj.name; path=$proj.path")
+
+                    def resolvableConfigs = findProjectConfigs(proj, confNameFilter, confAttrSpec)
+                    def resolvedConfigs = []
+                    resolvableConfigs.each({ config ->
+                        def resConf = config.resolvedConfiguration
+                        snykEcho("config `$config.name' resolution has errors: ${resConf.hasError()}")
+                        if (!resConf.hasError()) {
+                            resolvedConfigs.add(resConf)
+                            snykEcho("first level module dependencies for config `$config.name': $resConf.firstLevelModuleDependencies")
+                        }
+                    })
+                    if (resolvedConfigs.isEmpty() && !proj.configurations.isEmpty()) {
+                        throw new RuntimeException('Matching configurations not found: ' + confNameFilter +
+                                ', available configurations for project ' + proj + ': '
+                                + proj.configurations.collect { it.name })
+                    }
+
+                    def nonemptyFirstLevelDeps = resolvedConfigs.resolvedConfiguration.firstLevelModuleDependencies.findAll({ !it.isEmpty() })
+                    snykEcho("non-empty first level deps for project `$proj.name': $nonemptyFirstLevelDeps")
+
+                    snykEcho('converting gradle graph to snyk-graph format')
+                    def projGraph = getSnykGraph(nonemptyFirstLevelDeps)
+                    def projKey = proj.name
+                    if (projectsDict.get(projKey)) {
+                        snykEcho("The deps dict already has a project with key `$projKey'; using the full path")
+                        projKey = proj.path.replace(':', '/').replaceAll(~/(^\/+?)|(\/+$)/, '')
+                        if (projKey == "") {
+                            snykEcho("project path is empty (proj.path=$proj.path)! will use defaultProjectName=$defaultProjectName")
+                            projKey = defaultProjectName
+                        }
+                    }
+                    projectsDict[projKey] = [
+                            'targetFile'    : findProject(proj.path).buildFile.toString(),
+                            'snykGraph'     : projGraph,
+                            'projectVersion': proj.version.toString()
+                    ]
+                }
+
+                def result = [
+                        'defaultProject'    : defaultProjectName,
+                        'projects'          : projectsDict,
+                        'allSubProjectNames': allSubProjectNames
+                ]
+                def jsonDeps = JsonOutput.toJson(result)
+                println("JSONDEPS $jsonDeps")
+                snykDepsConfExecuted = true
+            }
+        }
+    }
+}

--- a/src/test/groovy/wooga/gradle/snyk/wdk/java/JavaSnykConventionsPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/snyk/wdk/java/JavaSnykConventionsPluginSpec.groovy
@@ -20,15 +20,11 @@ import nebula.test.ProjectSpec
 import spock.lang.Unroll
 import wooga.gradle.snyk.SnykPlugin
 import wooga.gradle.snyk.SnykRootPluginExtension
-import wooga.gradle.snyk.cli.BusinessCriticalityOption
-import wooga.gradle.snyk.cli.EnvironmentOption
-import wooga.gradle.snyk.cli.FailOnOption
-import wooga.gradle.snyk.cli.LifecycleOption
-import wooga.gradle.snyk.cli.SeverityThresholdOption
+import wooga.gradle.snyk.cli.*
 
 class JavaSnykConventionsPluginSpec extends ProjectSpec {
 
-    public static  final String SNYK_PLUGIN_ID = "net.wooga.snyk"
+    public static final String SNYK_PLUGIN_ID = "net.wooga.snyk"
     public static final String PLUGIN_ID = 'net.wooga.snyk-wdk-java'
 
     def "does not die if the snyk plugin is not applied"() {
@@ -65,7 +61,7 @@ class JavaSnykConventionsPluginSpec extends ProjectSpec {
         snykExtension.projectEnvironment.get() == [EnvironmentOption.internal]
         snykExtension.projectBusinessCriticality.get() == [BusinessCriticalityOption.low]
         snykExtension.projectTags.get() == ["team": "atlas", "component": "library", "platform": "jvm", "language": "groovy"]
-
+        snykExtension.initScript.get().asFile.text == snykInitScript
         snykExtension.autoDownload.get()
         snykExtension.strategies.get() == [SnykPlugin.MONITOR_CHECK]
         snykExtension.failOn.get() == FailOnOption.all
@@ -77,4 +73,14 @@ class JavaSnykConventionsPluginSpec extends ProjectSpec {
         false      | "before"
     }
 
+    static String getSnykInitScript() {
+        def out
+        try {
+            InputStream is = JavaSnykConventionsPlugin.class.getResourceAsStream("/snyk/snyk_init.gradle")
+            out = is.getText()
+        } catch (NullPointerException e) {
+            throw new FileNotFoundException("File " + "snyk/snyk_init.gradle" + " was not found inside JAR.");
+        }
+        out
+    }
 }


### PR DESCRIPTION
## Description

Snyk can not report on `buildScript` dependencies like plugins and custom build time libraries. I created a custom script which overrides the default script from snyk which is included in the snyk cli. The only way of replacing it is to force override the script. I don't want to handle this in the main plugin as this is a pretty dirty workaround which might break in the future.

## Changes

* ![ADD] convention for a custom `init-scritp` to report buildScript dependencies

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
