### PR TITLE
Add snyk monitoring [ATLAS-709]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,9 @@
  */
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-withCredentials([string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
+withCredentials([string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
+string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')
+]) {
 
     buildGradlePlugin platforms: ['macos','windows','linux'],
                       sonarToken: sonar_token

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,10 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '3.0.0'
+    id 'net.wooga.plugins' version '3.1.0'
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-gradle-plugin" version "0.2.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
 group 'net.wooga.snyk'
@@ -41,8 +44,12 @@ github {
     repositoryName = "wooga/atlas-snyk-wdk-java"
 }
 
+cveHandler {
+    configurations("compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath", "integrationTestCompileClasspath", "integrationTestRuntimeClasspath")
+}
+
 dependencies {
-    implementation 'com.wooga.gradle:gradle-commons:[1,2)'
-    implementation "net.wooga.gradle:atlas-snyk:0.9.0"
-    testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2)'
+    implementation 'com.wooga.gradle:gradle-commons:[1,2['
+    implementation "net.wooga.gradle:atlas-snyk:0.10.0"
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,5 +20,11 @@ include 'shared'
 include 'api'
 include 'services:webservice'
 */
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
 
 rootProject.name = 'atlas-snyk-wdk-java'


### PR DESCRIPTION
## Decription

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin net.wooga.cve-dependency-resolution which applies overrides for dependencies with know fixes for security issues.

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
